### PR TITLE
add support for IPv6

### DIFF
--- a/lib/Test/POE/Client/TCP.pm
+++ b/lib/Test/POE/Client/TCP.pm
@@ -6,7 +6,8 @@ use strict;
 use warnings;
 use POE qw(Wheel::SocketFactory Wheel::ReadWrite Filter::Line);
 use POSIX qw[ETIMEDOUT];
-use Socket;
+use Socket qw(AF_INET AF_INET6 SOCK_STREAM inet_ntoa inet_ntop inet_pton
+              unpack_sockaddr_in unpack_sockaddr_in6);
 use Carp qw(carp croak);
 
 our $GOT_SSL;
@@ -159,6 +160,8 @@ sub _connect {
     return;
   }
 
+  $self->{domain} =
+    defined( inet_pton( AF_INET6, $self->{address} ) ) ? AF_INET6 : AF_INET;
   $self->{factory} = POE::Wheel::SocketFactory->new(
     RemoteAddress  => $self->{address},
     RemotePort     => $self->{port},
@@ -166,7 +169,7 @@ sub _connect {
     ( defined $self->{port} ? ( BindPort => $self->{localport} ) : () ),
     SuccessEvent   => '_socket_up',
     FailureEvent   => '_socket_fail',
-    SocketDomain   => AF_INET,             # Sets the socket() domain
+    SocketDomain   => $self->{domain},     # Sets the socket() domain
     SocketType     => SOCK_STREAM,         # Sets the socket() type
     SocketProtocol => 'tcp',               # Sets the socket() protocol
     Reuse          => 'yes',               # Lets the port be reused
@@ -178,9 +181,12 @@ sub _connect {
 
 sub _socket_up {
   my ($kernel,$self,$socket,$peeraddr,$peerport) = @_[KERNEL,OBJECT,ARG0..ARG2];
-  my $sockaddr = inet_ntoa( ( unpack_sockaddr_in ( CORE::getsockname $socket ) )[1] );
-  my $sockport = ( unpack_sockaddr_in ( CORE::getsockname $socket ) )[0];
-  $peeraddr = inet_ntoa( $peeraddr );
+  my @sockaddr = ( $self->{domain} == AF_INET6 )
+               ? unpack_sockaddr_in6 ( CORE::getsockname $socket )
+               : unpack_sockaddr_in  ( CORE::getsockname $socket );
+  my $sockaddr = inet_ntop( $self->{domain}, $sockaddr[1] );
+  my $sockport = $sockaddr[0];
+  $peeraddr = inet_ntop( $self->{domain}, $peeraddr );
   $kernel->delay( '_timeout' );
 
   delete $self->{factory};

--- a/t/01_spawn_ipv6.t
+++ b/t/01_spawn_ipv6.t
@@ -1,0 +1,117 @@
+use strict;
+use Socket;
+use Test::More;
+
+BEGIN {
+    eval('Socket::AF_INET6') or plan skip_all => 'AF_INET6 not available';
+};
+
+plan tests => 12;
+use POE qw(Wheel::SocketFactory Wheel::ReadWrite Filter::Line);
+use_ok('Test::POE::Client::TCP');
+
+POE::Session->create(
+  package_states => [
+	'main' => [qw(
+			_start
+			_accept
+			_failed
+			_sock_in
+			_sock_err
+			testc_registered
+			testc_connected
+			testc_disconnected
+			testc_input
+			testc_flushed
+	)],
+  ],
+);
+
+$poe_kernel->run();
+exit 0;
+
+sub _start {
+  my ($kernel,$heap) = @_[KERNEL,HEAP];
+  $heap->{listener} = POE::Wheel::SocketFactory->new(
+      BindAddress    => '::1',
+      SuccessEvent   => '_accept',
+      FailureEvent   => '_failed',
+      SocketDomain   => AF_INET6,            # Sets the socket() domain
+      SocketType     => SOCK_STREAM,         # Sets the socket() type
+      SocketProtocol => 'tcp',               # Sets the socket() protocol
+      Reuse          => 'on',                # Lets the port be reused
+  );
+  $heap->{testc} = Test::POE::Client::TCP->spawn();
+  isa_ok( $heap->{testc}, 'Test::POE::Client::TCP' );
+  return;
+}
+
+sub _accept {
+  my ($kernel,$heap,$socket) = @_[KERNEL,HEAP,ARG0];
+  my $wheel = POE::Wheel::ReadWrite->new(
+      Handle       => $socket,
+      InputEvent   => '_sock_in',
+      ErrorEvent   => '_sock_err',
+  );
+  $heap->{wheels}->{ $wheel->ID } = $wheel;
+  return;
+}
+
+sub _failed {
+  my ($kernel,$heap,$operation,$errnum,$errstr,$wheel_id) = @_[KERNEL,HEAP,ARG0..ARG3];
+  die "Wheel $wheel_id generated $operation error $errnum: $errstr\n";
+  return;
+}
+
+sub _sock_in {
+  my ($heap,$input,$wheel_id) = @_[HEAP,ARG0,ARG1];
+  pass('Got input from client');
+  $heap->{wheels}->{ $wheel_id }->put( $input ) if $heap->{wheels}->{ $wheel_id };
+  return;
+}
+
+sub _sock_err {
+  my ($heap,$wheel_id) = @_[HEAP,ARG3];
+  pass('Client disconnected');
+  delete $heap->{wheels}->{ $wheel_id };
+  return;
+}
+
+sub testc_registered {
+  my ($kernel,$sender,$object) = @_[KERNEL,SENDER,ARG0];
+  pass($_[STATE]);
+  isa_ok( $object, 'Test::POE::Client::TCP' );
+  my $port = ( sockaddr_in6( $_[HEAP]->{listener}->getsockname() ) )[0];
+  $kernel->post( $sender, 'connect', { address => '::1', port => $port } );
+  return;
+}
+
+sub testc_connected {
+  my ($kernel,$sender) = @_[KERNEL,SENDER];
+  pass($_[STATE]);
+  isa_ok( $_[HEAP]->{testc}->wheel, 'POE::Wheel::ReadWrite' );
+  $kernel->post( $sender, 'send_to_server', 'Hello, is it me you are looking for?' );
+  return;
+}
+
+sub testc_flushed {
+  pass($_[STATE]);
+  return;
+}
+
+sub testc_input {
+  my ($heap,$input) = @_[HEAP,ARG0];
+  pass('Got something back from the server');
+  ok( $input eq 'Hello, is it me you are looking for?', $input );
+  $heap->{testc}->terminate();
+  return;
+}
+
+sub testc_disconnected {
+  my ($heap,$state) = @_[HEAP,STATE];
+  pass($state);
+  delete $heap->{wheels};
+  delete $heap->{listener};
+  $heap->{testc}->shutdown();
+  return;
+}


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Test-POE-Client-TCP.
We thought you might be interested in it too.

    Description: add support for IPv6
     Recognise and support IPv6 addresses
    Author: Damyan Ivanov <dmn@debian.org>

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libtest-poe-client-tcp-perl/raw/master/debian/patches/ipv6.patch

Thanks for considering,
  Damyan Ivanov,
  Debian Perl Group
